### PR TITLE
feat: Describe palette, minor color adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # everforest-slack
-🌲 Comfortable &amp; Pleasant Color Scheme for Slack Inspired by sainnhe/everforest.
 
-![everforest-slack-png](https://github.com/itendtostare/everforest-slack/blob/main/slack-everforest.png?raw=true "Optional Title")
+🌲 Comfortable &amp; Pleasant Color Scheme for Slack Inspired by [sainnhe/everforest](https://github.com/sainnhe/everforest/).
+
+![everforest-slack-png](./slack-everforest.png "Everforest theme for Slack")
 
 
 ## Introduction
@@ -13,7 +14,21 @@ Everforest is a green based color scheme, it's designed to be warm and soft in o
 - In Slack, click on the workspace icon and open the preferences pane
 - Navigate to the Themes section and paste the following
 
-```#2B3339,#3B4252,#7C8377,#1E2327,#445055,#D3C6AA,#83C092,#B67073,#445055,#7C8377```
+`#2B3339,#445055,#7A8478,#1E2327,#445055,#D3C6AA,#83C092,#BD6769,#445055,#7A8478`
+
+### Color Palette
+
+The colors in this theme correspond to the following colors in the _dark medium_ Everforest [palette](https://github.com/sainnhe/everforest/blob/d616344e/autoload/everforest.vim#L31):
+
+|                                                              | Hex     | Identifier        | Usages                    |
+|--------------------------------------------------------------|---------|-------------------|---------------------------|
+| ![#1E2327](https://via.placeholder.com/16/1E2327/1E2327.png) | #1E2327 | `bg0` (30% shade) | Active Item Text          |
+| ![#2B3339](https://via.placeholder.com/16/2B3339/2B3339.png) | #2B3339 | `bg0`             | Column BG                 |
+| ![#445055](https://via.placeholder.com/16/445055/445055.png) | #445055 | `bg3`             | Top Nav BG, Hover Item    |
+| ![#7A8478](https://via.placeholder.com/16/7A8478/7A8478.png) | #7A8478 | `grey0`           | Active Item, Top Nav Text |
+| ![#D3C6AA](https://via.placeholder.com/16/D3C6AA/D3C6AA.png) | #D3C6AA | `fg`              | Text Color                |
+| ![#BD6769](https://via.placeholder.com/16/BD6769/BD6769.png) | #BD6769 | `red` (18% shade) | Mention Badge             |
+| ![#83C092](https://via.placeholder.com/16/83C092/83C092.png) | #83C092 | `aqua`            | Active Presence           |
 
 ## Documentation
 


### PR DESCRIPTION
First of all, thanks for creating this Slack theme and sharing it in the Everforest wiki, it looks great! (I'm one of the three maintainers of the Vim color scheme.) 

I would like to suggest the addition of the table below to the README to document what colors of the original palette were used in this theme, and their possible variations where relevant:

|                                                              | Hex       | Identifier        | Usages                    |
|--------------------------------------------------------------|-----------|-------------------|---------------------------|
| ![#1E2327](https://via.placeholder.com/16/1E2327/1E2327.png) | #1E2327 | `bg0` (30% shade) | Active Item Text          |
| ![#2B3339](https://via.placeholder.com/16/2B3339/2B3339.png) | #2B3339 | `bg0`             | Column BG                 |
| ![#445055](https://via.placeholder.com/16/445055/445055.png) | #445055 | `bg3`             | Top Nav BG, Hover Item    |
| ![#7A8478](https://via.placeholder.com/16/7A8478/7A8478.png) | #7A8478 | `grey0`           | Active Item, Top Nav Text |
| ![#D3C6AA](https://via.placeholder.com/16/D3C6AA/D3C6AA.png) | #D3C6AA | `fg`              | Text Color                |
| ![#BD6769](https://via.placeholder.com/16/BD6769/BD6769.png) | #BD6769 | `red` (18% shade) | Mention Badge             |
| ![#83C092](https://via.placeholder.com/16/83C092/83C092.png) | #83C092 | `aqua`            | Active Presence           |

Additionally, since I wasn't able to figure out where the colors for active/mention of this theme originated from in relation to the Everforest color palette, I included a suggestion to replace them with either an original or a shade of one of the colors of the actual palette. This is mostly for fidelity and documentation purposes. I'm fine reverting that change if you don't like it, and explain how the current `#7C8377` and `#B67073` were chosen.

Before/after:

![#7C8377](https://via.placeholder.com/16/7C8377/7C8377.png)![#7A8478](https://via.placeholder.com/16/7A8478/7A8478.png)
![#B67073](https://via.placeholder.com/16/B67073/B67073.png)![#BD6769](https://via.placeholder.com/16/BD6769/BD6769.png)