### PR TITLE
update to new slack theme and add other shades

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Everforest is a green based color scheme, it's designed to be warm and soft in o
 
 ### Installation
 
+- Copy one of the theme strings from below.
 - In Slack, click on the workspace icon and open the **Preferences** pane.
 - Navigate to the **Themes** section, select **Custom theme**, then **Import** and paste theme you copied.
 
@@ -22,7 +23,7 @@ _For more info see [Slack Help Center | Change your Slack theme](https://slack.c
 #### Dark - hard
 
 ```
-#2B3339,#7A8478,#83C092,#BD6769
+#272E33,#7A8478,#83C092,#E67E80
 ```
 
 #### Dark - medium
@@ -34,7 +35,13 @@ _For more info see [Slack Help Center | Change your Slack theme](https://slack.c
 #### Dark - soft
 
 ```
-#2B3339,#7A8478,#83C092,#BD6769
+#333C43,#7A8478,#83C092,#E67E80
+```
+
+#### Light - hard
+
+```
+#FFFBEF,#A6B0A0,#35A77C,#F85552
 ```
 
 #### Light - medium
@@ -43,18 +50,24 @@ _For more info see [Slack Help Center | Change your Slack theme](https://slack.c
 #FFF9E8,#A6B0A0,#35A77C,#F85552
 ```
 
+#### Light - soft
+
+```
+#FFFAE8,#A6B0A0,#35A77C,#F85552
+```
+
 ### Color Palette
 
 The colors in these themes are taken from the main Everforest [palettes](https://github.com/sainnhe/everforest/blob/master/palette.md):
 
 
-|                     |            | Dark |                                                                      |      | Light |        |      |
-|---------------------|------------|------|----------------------------------------------------------------------|------|-------|--------|------|
-| Slack color         | Identifier | Hard | Medium                                                               | Soft | Hard  | Medium | Soft |
-| Sytem navigation    | `bg0`      |      | ![#2B3339](https://via.placeholder.com/16/2B3339/2B3339.png) #2B3339 |      |       | ![#FFF9E8](https://via.placeholder.com/16/FFF9E8/FFF9E8.png) #FFF9E8 |      |
-| Selected items      | `grey0`    |      | ![#7A8478](https://via.placeholder.com/16/7A8478/7A8478.png) #7A8478 |      |       | ![#A6B0A0](https://via.placeholder.com/16/A6B0A0/A6B0A0.png) #A6B0A0       |      |
-| Presence indication | `aqua`     |      | ![#83C092](https://via.placeholder.com/16/83C092/83C092.png) #83C092 |       |      | ![#35A77C](https://via.placeholder.com/16/35A77C/35A77C.png) #35A77C      |        |
-| Notifications       | `red`      |      | ![#BD6769](https://via.placeholder.com/16/BD6769/BD6769.png) #BD6769 |       |      | ![#F85552](https://via.placeholder.com/16/F85552/F85552.png) #F85552      |        |
+|                     |            | Dark                                                                 |                                                                      |                                                                      | Light                                                                |                                                                      |                                                                      |
+|---------------------|------------|----------------------------------------------------------------------|----------------------------------------------------------------------|----------------------------------------------------------------------|----------------------------------------------------------------------|----------------------------------------------------------------------|----------------------------------------------------------------------|
+| Slack color         | Identifier | Hard                                                                 | Medium                                                               | Soft                                                                 | Hard                                                                 | Medium                                                               | Soft                                                                 |
+| Sytem navigation    | `bg0`      | ![#272E33](https://via.placeholder.com/16/272E33/272E33.png) #272E33 | ![#2B3339](https://via.placeholder.com/16/2B3339/2B3339.png) #2B3339 | ![#333C43](https://via.placeholder.com/16/333C43/333C43.png) #333C43 | ![#FFFBEF](https://via.placeholder.com/16/FFFBEF/FFFBEF.png) #FFFBEF | ![#FFF9E8](https://via.placeholder.com/16/FFF9E8/FFF9E8.png) #FFF9E8 | ![#FFF9E8](https://via.placeholder.com/16/FFF9E8/FFF9E8.png) #FFFAE8 |
+| Selected items      | `grey0`    | ![#7A8478](https://via.placeholder.com/16/7A8478/7A8478.png) #7A8478 | ![#7A8478](https://via.placeholder.com/16/7A8478/7A8478.png) #7A8478 | ![#7A8478](https://via.placeholder.com/16/7A8478/7A8478.png) #7A8478 | ![#A6B0A0](https://via.placeholder.com/16/A6B0A0/A6B0A0.png) #A6B0A0 | ![#A6B0A0](https://via.placeholder.com/16/A6B0A0/A6B0A0.png) #A6B0A0 | ![#A6B0A0](https://via.placeholder.com/16/A6B0A0/A6B0A0.png) #A6B0A0 |
+| Presence indication | `aqua`     | ![#83C092](https://via.placeholder.com/16/83C092/83C092.png) #83C092 | ![#83C092](https://via.placeholder.com/16/83C092/83C092.png) #83C092 | ![#83C092](https://via.placeholder.com/16/83C092/83C092.png) #83C092 | ![#35A77C](https://via.placeholder.com/16/35A77C/35A77C.png) #35A77C | ![#35A77C](https://via.placeholder.com/16/35A77C/35A77C.png) #35A77C | ![#35A77C](https://via.placeholder.com/16/35A77C/35A77C.png) #35A77C |
+| Notifications       | `red`      | ![#E67E80](https://via.placeholder.com/16/E67E80/E67E80.png) #E67E80 | ![#BD6769](https://via.placeholder.com/16/BD6769/BD6769.png) #BD6769 | ![#E67E80](https://via.placeholder.com/16/E67E80/E67E80.png) #E67E80 | ![#F85552](https://via.placeholder.com/16/F85552/F85552.png) #F85552 | ![#F85552](https://via.placeholder.com/16/F85552/F85552.png) #F85552 | ![#F85552](https://via.placeholder.com/16/F85552/F85552.png) #F85552 |
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -11,24 +11,51 @@ Everforest is a green based color scheme, it's designed to be warm and soft in o
 
 ### Installation
 
-- In Slack, click on the workspace icon and open the preferences pane
-- Navigate to the Themes section and paste the following
+- In Slack, click on the workspace icon and open the **Preferences** pane.
+- Navigate to the **Themes** section, select **Custom theme**, then **Import** and paste theme you copied.
 
-`#2B3339,#3B4252,#7A8478,#1E2327,#445055,#D3C6AA,#83C092,#BD6769,#445055,#7A8478`
+_For more info see [Slack Help Center | Change your Slack theme](https://slack.com/intl/en-gb/help/articles/205166337-Change-your-Slack-theme#import-your-legacy-theme)._
+
+
+### Themes
+
+#### Dark - hard
+
+```
+#2B3339,#7A8478,#83C092,#BD6769
+```
+
+#### Dark - medium
+
+```
+#2B3339,#7A8478,#83C092,#BD6769
+```
+
+#### Dark - soft
+
+```
+#2B3339,#7A8478,#83C092,#BD6769
+```
+
+#### Light - medium
+
+```
+#FFF9E8,#A6B0A0,#35A77C,#F85552
+```
 
 ### Color Palette
 
-The colors in this theme correspond to the following colors in the _dark medium_ Everforest [palette](https://github.com/sainnhe/everforest/blob/d616344e/autoload/everforest.vim#L31):
+The colors in these themes are taken from the main Everforest [palettes](https://github.com/sainnhe/everforest/blob/master/palette.md):
 
-|                                                              | Hex     | Identifier        | Usages                    |
-|--------------------------------------------------------------|---------|-------------------|---------------------------|
-| ![#1E2327](https://via.placeholder.com/16/1E2327/1E2327.png) | #1E2327 | `bg0` (30% shade) | Active Item Text          |
-| ![#2B3339](https://via.placeholder.com/16/2B3339/2B3339.png) | #2B3339 | `bg0`             | Column BG                 |
-| ![#445055](https://via.placeholder.com/16/445055/445055.png) | #445055 | `bg3`             | Top Nav BG, Hover Item    |
-| ![#7A8478](https://via.placeholder.com/16/7A8478/7A8478.png) | #7A8478 | `grey0`           | Active Item, Top Nav Text |
-| ![#D3C6AA](https://via.placeholder.com/16/D3C6AA/D3C6AA.png) | #D3C6AA | `fg`              | Text Color                |
-| ![#BD6769](https://via.placeholder.com/16/BD6769/BD6769.png) | #BD6769 | `red` (18% shade) | Mention Badge             |
-| ![#83C092](https://via.placeholder.com/16/83C092/83C092.png) | #83C092 | `aqua`            | Active Presence           |
+
+|                     |            | Dark |                                                                      |      | Light |        |      |
+|---------------------|------------|------|----------------------------------------------------------------------|------|-------|--------|------|
+| Slack color         | Identifier | Hard | Medium                                                               | Soft | Hard  | Medium | Soft |
+| Sytem navigation    | `bg0`      |      | ![#2B3339](https://via.placeholder.com/16/2B3339/2B3339.png) #2B3339 |      |       | ![#FFF9E8](https://via.placeholder.com/16/FFF9E8/FFF9E8.png) #FFF9E8 |      |
+| Selected items      | `grey0`    |      | ![#7A8478](https://via.placeholder.com/16/7A8478/7A8478.png) #7A8478 |      |       | ![#A6B0A0](https://via.placeholder.com/16/A6B0A0/A6B0A0.png) #A6B0A0       |      |
+| Presence indication | `aqua`     |      | ![#83C092](https://via.placeholder.com/16/83C092/83C092.png) #83C092 |       |      | ![#35A77C](https://via.placeholder.com/16/35A77C/35A77C.png) #35A77C      |        |
+| Notifications       | `red`      |      | ![#BD6769](https://via.placeholder.com/16/BD6769/BD6769.png) #BD6769 |       |      | ![#F85552](https://via.placeholder.com/16/F85552/F85552.png) #F85552      |        |
+
 
 ## Documentation
 


### PR DESCRIPTION
Slack changed the way their themes work a few months ago: https://www.techfinitive.com/features/hot-to-make-slacks-new-design-better/

The main change from this is that they're streamlined to just four hex codes now, with some sort of inferencing of complementing colours that work.

I've updated the original theme from this repo to work with this new layout, and added the other five shades of Everforest here.